### PR TITLE
Add Binary Struct and BinaryDefinition Trait

### DIFF
--- a/src-tauri/src/binary/mod.rs
+++ b/src-tauri/src/binary/mod.rs
@@ -1,0 +1,98 @@
+#[cfg(test)]
+mod test;
+
+use crate::error::PIVXErrors;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Child, Command};
+
+pub trait BinaryDefinition {
+    fn get_url(&self) -> &str;
+    fn get_sha256sum(&self) -> &str;
+    fn get_archive_name(&self) -> &str;
+    fn decompress_archive(&self, dir: &PathBuf) -> Result<(), PIVXErrors>;
+    fn get_binary_path(&self, base_dir: &PathBuf) -> PathBuf;
+    fn get_binary_args(&self, base_dir: &PathBuf) -> Result<String, PIVXErrors>;
+}
+
+pub struct Binary {
+    handle: Child,
+}
+
+impl Drop for Binary {
+    fn drop(&mut self) {
+        // This sends SIGKILL so this should be refactored to send SIGTERM
+        self.handle.kill().expect("Failed to kill pivxd");
+        self.handle.wait().expect("Failed to wait");
+    }
+}
+
+impl Binary {
+    /**
+     * Fetches a binary and copies it into $XDG_DATA_HOME/pivx-rust or equivalent based on OS
+     */
+    async fn fetch<T: BinaryDefinition + Send>(
+        dir: &PathBuf,
+        binary_definition: &T,
+    ) -> Result<(), PIVXErrors> {
+        let mut request = reqwest::get(binary_definition.get_url()).await?;
+        if !request.status().is_success() {
+            return Err(PIVXErrors::ServerError);
+        }
+        std::fs::create_dir_all(&dir)?;
+        let file_path = dir.join(binary_definition.get_archive_name());
+        let mut file = File::create(&file_path)?;
+        while let Some(chunk) = request.chunk().await? {
+            file.write_all(&chunk)?;
+        }
+
+        let digest =
+            sha256::try_digest(&file_path).map_err(|e| PIVXErrors::WrongSha256Sum(Some(e)))?;
+        if digest != binary_definition.get_sha256sum() {
+            Err(PIVXErrors::WrongSha256Sum(None))
+        } else {
+            Ok(())
+        }
+    }
+
+    #[cfg(not(test))]
+    pub fn get_data_dir() -> Result<PathBuf, PIVXErrors> {
+        Ok(dirs::data_dir()
+            .ok_or(PIVXErrors::NoDataDir)?
+            .join("pivx-rust"))
+    }
+
+    #[cfg(test)]
+    pub fn get_data_dir() -> Result<PathBuf, PIVXErrors> {
+        use tempdir::TempDir;
+        Ok(TempDir::new("pivx-rust")?.into_path())
+    }
+
+    fn new_by_path<T: BinaryDefinition + Send>(
+        path: &str,
+        binary_definition: &T,
+    ) -> Result<Self, PIVXErrors> {
+        let data_dir = Self::get_data_dir()?.join(".pivx");
+        if !data_dir.exists() {
+            std::fs::create_dir_all(&data_dir)?;
+        }
+        let handle = Command::new(path)
+            .arg(binary_definition.get_binary_args(&data_dir)?)
+            .spawn()
+            .map_err(|_| PIVXErrors::PivxdNotFound)?;
+        Ok(Binary { handle })
+    }
+
+    pub async fn new_by_fetching<T: BinaryDefinition + Send>(
+        binary_definition: &T,
+    ) -> Result<Self, PIVXErrors> {
+        let data_dir = Self::get_data_dir()?;
+        let binary_path = binary_definition.get_binary_path(&data_dir);
+        if !binary_path.exists() {
+            Self::fetch(&data_dir, binary_definition).await?;
+            binary_definition.decompress_archive(&data_dir)?;
+        }
+        Self::new_by_path(&*binary_path.to_string_lossy(), binary_definition)
+    }
+}

--- a/src-tauri/src/binary/test.rs
+++ b/src-tauri/src/binary/test.rs
@@ -1,0 +1,66 @@
+use super::*;
+use std::fs::File;
+use tempdir::TempDir;
+
+struct TestBinary {
+    url: String,
+}
+
+impl BinaryDefinition for TestBinary {
+    fn get_url(&self) -> &str {
+        &self.url
+    }
+    fn get_sha256sum(&self) -> &str {
+        "398e8a1a206f898139947a2003bf738c0f39b63f5d9a3116a68d6f483421b0b5"
+    }
+    fn get_archive_name(&self) -> &str {
+        "a.tar.gz"
+    }
+    fn decompress_archive(&self, dir: &PathBuf) -> Result<(), PIVXErrors> {
+        Ok(())
+    }
+    fn get_binary_path(&self, base_dir: &PathBuf) -> PathBuf {
+        unimplemented!()
+    }
+    fn get_binary_args(&self, _: &PathBuf) -> Result<String, PIVXErrors> {
+        unimplemented!()
+    }
+}
+mod pivx_fetch {
+    use super::*;
+    #[tokio::test]
+    async fn fetches_the_binary_correctly() -> Result<(), PIVXErrors> {
+        let data_dir = Binary::get_data_dir()?;
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/")
+            .with_body("PIVX Source code")
+            .create_async()
+            .await;
+        let binary_definition = TestBinary { url: server.url() };
+        Binary::fetch(&data_dir, &binary_definition).await?;
+
+        let content = std::fs::read_to_string(data_dir.join("a.tar.gz"))?;
+        assert_eq!(content, "PIVX Source code");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn returns_error_when_server_returns_404() -> Result<(), PIVXErrors> {
+        let data_dir = Binary::get_data_dir()?;
+        let mut server = mockito::Server::new_async().await;
+        let m1 = server
+            .mock("GET", "/")
+            .with_status(500)
+            .with_body("Internal server error.")
+            .create_async()
+            .await;
+        let binary_definition = TestBinary { url: server.url() };
+        match Binary::fetch(&data_dir, &binary_definition).await {
+            Err(x) => {}
+            Ok(_) => panic!("Shuold return error"),
+        };
+
+        Ok(())
+    }
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,0 +1,26 @@
+#![allow(unused)]
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum PIVXErrors {
+    #[error("Failed to fetch data")]
+    FetchError(#[from] reqwest::Error),
+
+    #[error("Server returned a non-ok status code")]
+    ServerError,
+
+    #[error("No data directory found")]
+    NoDataDir,
+
+    #[error("Failed to create file")]
+    CreateFileError(#[from] std::io::Error),
+
+    #[error("Pivxd not found")]
+    PivxdNotFound,
+
+    #[error("Invalid sha256 sum")]
+    WrongSha256Sum(Option<std::io::Error>),
+}
+
+pub type Result<T> = std::result::Result<T, PIVXErrors>;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,12 +1,17 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use pivx::PIVXDefinition;
+
+mod binary;
+mod error;
 mod pivx;
 
 // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
 #[tauri::command]
 async fn greet() -> String {
-    let pivx = pivx::PIVX::new_by_fetching()
+    let pivx_definition = PIVXDefinition;
+    let pivx = binary::Binary::new_by_fetching(&pivx_definition)
         .await
         .expect("Failed to run PIVX");
     // Leaking for now to bypass Drop

--- a/src-tauri/src/pivx/mod.rs
+++ b/src-tauri/src/pivx/mod.rs
@@ -1,95 +1,25 @@
 #[cfg(test)]
 mod test;
 
+use crate::error::PIVXErrors;
 use flate2::read::GzDecoder;
 use std::fs::File;
-use std::io::{Read, Write};
 use std::path::PathBuf;
-use std::process::{Child, Command};
 use tar::Archive;
-use thiserror::Error;
 
-#[derive(Error, Debug)]
-pub enum PIVXErrors {
-    #[error("Failed to fetch data")]
-    FetchError(#[from] reqwest::Error),
+use crate::binary::BinaryDefinition;
 
-    #[error("Server returned a non-ok status code")]
-    ServerError,
+pub struct PIVXDefinition;
 
-    #[error("No data directory found")]
-    NoDataDir,
-
-    #[error("Failed to create file")]
-    CreateFileError(#[from] std::io::Error),
-
-    #[error("Pivxd not found")]
-    PivxdNotFound,
-
-    #[error("Invalid sha256 sum")]
-    WrongSha256Sum(Option<std::io::Error>),
-}
-
-pub struct PIVX {
-    handle: Child,
-}
-
-impl Drop for PIVX {
-    fn drop(&mut self) {
-        // This sends SIGKILL so this should be refactored to send SIGTERM
-        self.handle.kill().expect("Failed to kill pivxd");
-        self.handle.wait().expect("Failed to wait");
-    }
-}
-
-impl PIVX {
-    /**
-     * Fetches pivxd and copies it into $XDG_DATA_HOME/pivx-rust or equivalent based on OS
-     */
-    async fn fetch(pivxd_url: &str, dir: &PathBuf) -> Result<(), PIVXErrors> {
-        let mut request = reqwest::get(pivxd_url.to_string()).await?;
-        if !request.status().is_success() {
-            return Err(PIVXErrors::ServerError);
-        }
-        std::fs::create_dir_all(&dir)?;
-        let file_path = dir.join("pivxd.tar.gz");
-        let mut file = File::create(&file_path)?;
-        while let Some(chunk) = request.chunk().await? {
-            file.write_all(&chunk)?;
-        }
-
-        let digest =
-            sha256::try_digest(&file_path).map_err(|e| PIVXErrors::WrongSha256Sum(Some(e)))?;
-        println!("{:?}", file_path.to_str());
-        println!("{}", digest);
-        if digest != Self::get_pivxd_sha256sum() {
-            Err(PIVXErrors::WrongSha256Sum(None))
-        } else {
-            Ok(())
-        }
-    }
-
-    fn decompress_archive(dir: &PathBuf) -> Result<(), PIVXErrors> {
+impl BinaryDefinition for PIVXDefinition {
+    fn decompress_archive(&self, dir: &PathBuf) -> Result<(), PIVXErrors> {
         let mut tarball = Archive::new(GzDecoder::new(File::open(dir.join("pivxd.tar.gz"))?));
         tarball.unpack(dir)?;
 
         Ok(())
     }
 
-    #[cfg(not(test))]
-    fn get_data_dir() -> Result<PathBuf, PIVXErrors> {
-        Ok(dirs::data_dir()
-            .ok_or(PIVXErrors::NoDataDir)?
-            .join("pivx-rust"))
-    }
-
-    #[cfg(test)]
-    fn get_data_dir() -> Result<PathBuf, PIVXErrors> {
-        use tempdir::TempDir;
-        Ok(TempDir::new("pivx-rust")?.into_path())
-    }
-
-    fn get_pivxd_url() -> &'static str {
+    fn get_url(&self) -> &str {
         #[cfg(target_os = "linux")]
 	return "https://github.com/PIVX-Project/PIVX/releases/download/v5.6.1/pivx-5.6.1-x86_64-linux-gnu.tar.gz";
 
@@ -99,13 +29,7 @@ impl PIVX {
         }
     }
 
-    #[cfg(test)]
-    fn get_pivxd_sha256sum() -> &'static str {
-        "398e8a1a206f898139947a2003bf738c0f39b63f5d9a3116a68d6f483421b0b5"
-    }
-
-    #[cfg(not(test))]
-    fn get_pivxd_sha256sum() -> &'static str {
+    fn get_sha256sum(&self) -> &str {
         #[cfg(target_os = "linux")]
         return "6704625c63ff73da8c57f0fbb1dab6f1e4bd8f62c17467e05f52a64012a0ee2f";
         #[allow(unreachable_code)]
@@ -114,32 +38,24 @@ impl PIVX {
         }
     }
 
-    fn new_by_path(path: &str) -> Result<Self, PIVXErrors> {
-        let data_dir = Self::get_data_dir()?.join(".pivx");
-        if !data_dir.exists() {
-            std::fs::create_dir_all(&data_dir)?;
+    fn get_archive_name(&self) -> &str {
+        #[cfg(target_os = "linux")]
+        return "pivxd.tar.gz";
+
+        #[allow(unreachable_code)]
+        {
+            panic!("Unsupported OS")
         }
-        let mut handle = Command::new(path)
-            .arg(format!(
-                "-datadir={}",
-                data_dir.to_str().ok_or(PIVXErrors::PivxdNotFound)?
-            ))
-            .spawn()
-            .map_err(|_| PIVXErrors::PivxdNotFound)?;
-        Ok(PIVX { handle })
     }
 
-    pub fn new() -> Result<Self, PIVXErrors> {
-        Self::new_by_path("pivxd")
+    fn get_binary_path(&self, base_dir: &PathBuf) -> PathBuf {
+        base_dir.join("pivx-5.6.1").join("bin").join("pivxd")
     }
 
-    pub async fn new_by_fetching() -> Result<Self, PIVXErrors> {
-        let data_dir = Self::get_data_dir()?;
-        let pivxd_path = data_dir.join("pivx-5.6.1").join("bin").join("pivxd");
-        if !pivxd_path.exists() {
-            Self::fetch(Self::get_pivxd_url(), &data_dir).await?;
-            Self::decompress_archive(&data_dir)?;
-        }
-        Self::new_by_path(&*pivxd_path.to_string_lossy())
+    fn get_binary_args(&self, base_dir: &PathBuf) -> Result<String, PIVXErrors> {
+        Ok(format!(
+            "-datadir={}",
+            base_dir.to_str().ok_or(PIVXErrors::PivxdNotFound)?
+        ))
     }
 }

--- a/src-tauri/src/pivx/test.rs
+++ b/src-tauri/src/pivx/test.rs
@@ -1,6 +1,6 @@
 use super::*;
 use std::fs::File;
-use tempdir::TempDir;
+use std::io::Write;
 
 mod pivx_fetch {
     use crate::binary::Binary;


### PR DESCRIPTION
Add a binary struct to more easily define binaries, for future binaries like the explorer.
It contains:
- The BinaryDefinition trait, which has the necessary data to download, decompress and run the binary;
- The Binary struct, which contains the shared code between each binary.
Tests were rewritten to use this trait