### PR TITLE
Add address indexer

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
  "gimli",
 ]
@@ -22,6 +22,18 @@ name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -70,9 +82,9 @@ checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "4e1496f8fb1fbf272686b8d37f523dab3e4a7443300055e74cdaa449f3114356"
 
 [[package]]
 name = "assert-json-diff"
@@ -133,17 +145,17 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.4",
+ "miniz_oxide 0.8.0",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -230,9 +242,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 
 [[package]]
 name = "byteorder"
@@ -282,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.15"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
 dependencies = [
  "shlex",
 ]
@@ -448,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -755,6 +767,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,12 +887,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -918,14 +958,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1073,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "gio"
@@ -1160,9 +1210,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1267,6 +1317,18 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1409,6 +1471,7 @@ dependencies = [
  "http 1.1.0",
  "hyper",
  "hyper-util",
+ "log",
  "rustls",
  "rustls-pki-types",
  "tokio",
@@ -1434,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1503,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1571,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
 name = "itoa"
@@ -1608,6 +1671,20 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps 5.0.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
 ]
 
 [[package]]
@@ -1663,6 +1740,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd1ead9fb95614e8dc5556d12a8681c2f6d352d0c1d3efc8708c7ccbba47bc6"
+dependencies = [
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "jsonrpsee-types",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff79651479f69ada7bda604ef2acf3f1aa50755d97cc36d25ff04c2664f9d96f"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-timer",
+ "futures-util",
+ "http 1.1.0",
+ "http-body",
+ "http-body-util",
+ "jsonrpsee-types",
+ "pin-project",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ed8b301b19f4dad8ddc66ed956a70fc227def5c19b3898e0a29ce8f0edee06"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "rustls",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e386460425e49679587871a056f2895a47dade21457324ad1262cd78ef6d9"
+dependencies = [
+ "http 1.1.0",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +1845,16 @@ dependencies = [
  "bitflags 2.6.0",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1885,12 +2044,16 @@ dependencies = [
 name = "mpw-tauri"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "derive_more 1.0.0",
  "dirs",
  "flate2",
+ "futures",
+ "jsonrpsee",
  "mockall",
  "mockito",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha256",
@@ -1970,10 +2133,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2612,9 +2794,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2742,10 +2924,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.6.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc_version"
@@ -2758,9 +2960,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.35"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -2771,15 +2973,30 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2799,10 +3016,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
-name = "rustls-webpki"
-version = "0.102.7"
+name = "rustls-platform-verifier"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
+checksum = "afbb878bdfdf63a336a5e63561b1835e7a8c91524f51621db870169eac84b490"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.19.0",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-roots",
+ "winapi",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2832,11 +3076,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2861,6 +3105,7 @@ dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "libc",
+ "num-bigint",
  "security-framework-sys",
 ]
 
@@ -2905,18 +3150,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2925,9 +3170,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "indexmap 2.5.0",
  "itoa 1.0.11",
@@ -3302,7 +3547,7 @@ dependencies = [
  "gtk",
  "image",
  "instant",
- "jni",
+ "jni 0.20.0",
  "lazy_static",
  "libc",
  "log",
@@ -3713,6 +3958,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3806,6 +4062,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3826,6 +4083,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3901,9 +4159,9 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
@@ -4162,6 +4420,15 @@ dependencies = [
  "pkg-config",
  "soup2-sys",
  "system-deps 6.2.2",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,11 @@ reqwest = "0.12.7"
 tar = "0.4.41"
 thiserror = "1.0.63"
 sha256 = "1.5.0"
+futures = "0.3.30"
+rusqlite = "0.32.1"
+jsonrpsee = { version = "0.24.4", features = ["async-client", "client-core", "http-client"] }
+tokio = "1.40.0"
+base64 = "0.22.1"
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!
@@ -30,5 +35,6 @@ full-node= []
 
 [dev-dependencies]
 mockito = "1.5.0"
+serde_json = "1"
 tempdir = "0.3.7"
 tokio = { version = "1.40.0", features = ["macros", "test-util"] }

--- a/src-tauri/src/address_index/block_source.rs
+++ b/src-tauri/src/address_index/block_source.rs
@@ -7,3 +7,36 @@ pub trait BlockSource {
         &mut self,
     ) -> crate::error::Result<Pin<Box<dyn Stream<Item = Block> + '_ + Send>>>;
 }
+
+#[cfg(test)]
+pub mod test {
+    use super::super::types::{Block, Tx};
+    use super::*;
+    pub struct MockBlockSource;
+    impl BlockSource for MockBlockSource {
+        fn get_blocks(
+            &mut self,
+        ) -> crate::error::Result<Pin<Box<dyn Stream<Item = Block> + '_ + Send>>> {
+            Ok(Box::pin(futures::stream::iter(vec![
+                Block {
+                    txs: vec![Tx {
+                        txid: "txid1".to_owned(),
+                        addresses: vec!["address1".to_owned(), "address2".to_owned()],
+                    }],
+                },
+                Block {
+                    txs: vec![Tx {
+                        txid: "txid2".to_owned(),
+                        addresses: vec!["address1".to_owned(), "address4".to_owned()],
+                    }],
+                },
+                Block {
+                    txs: vec![Tx {
+                        txid: "txid3".to_owned(),
+                        addresses: vec!["address1".to_owned(), "address5".to_owned()],
+                    }],
+                },
+            ])))
+        }
+    }
+}

--- a/src-tauri/src/address_index/block_source.rs
+++ b/src-tauri/src/address_index/block_source.rs
@@ -10,7 +10,7 @@ pub trait BlockSource {
 
 #[cfg(test)]
 pub mod test {
-    use super::super::types::{test::get_test_blocks, Block, Tx};
+    use super::super::types::{test::get_test_blocks, Block};
     use super::*;
 
     pub struct MockBlockSource;

--- a/src-tauri/src/address_index/block_source.rs
+++ b/src-tauri/src/address_index/block_source.rs
@@ -10,33 +10,16 @@ pub trait BlockSource {
 
 #[cfg(test)]
 pub mod test {
-    use super::super::types::{Block, Tx};
+    use super::super::types::{test::get_test_blocks, Block, Tx};
     use super::*;
+
     pub struct MockBlockSource;
+
     impl BlockSource for MockBlockSource {
         fn get_blocks(
             &mut self,
         ) -> crate::error::Result<Pin<Box<dyn Stream<Item = Block> + '_ + Send>>> {
-            Ok(Box::pin(futures::stream::iter(vec![
-                Block {
-                    txs: vec![Tx {
-                        txid: "txid1".to_owned(),
-                        addresses: vec!["address1".to_owned(), "address2".to_owned()],
-                    }],
-                },
-                Block {
-                    txs: vec![Tx {
-                        txid: "txid2".to_owned(),
-                        addresses: vec!["address1".to_owned(), "address4".to_owned()],
-                    }],
-                },
-                Block {
-                    txs: vec![Tx {
-                        txid: "txid3".to_owned(),
-                        addresses: vec!["address1".to_owned(), "address5".to_owned()],
-                    }],
-                },
-            ])))
+            Ok(Box::pin(futures::stream::iter(get_test_blocks())))
         }
     }
 }

--- a/src-tauri/src/address_index/block_source.rs
+++ b/src-tauri/src/address_index/block_source.rs
@@ -1,0 +1,9 @@
+use super::types::Block;
+use futures::stream::Stream;
+use std::pin::Pin;
+
+pub trait BlockSource {
+    fn get_blocks(
+        &mut self,
+    ) -> crate::error::Result<Pin<Box<dyn Stream<Item = Block> + '_ + Send>>>;
+}

--- a/src-tauri/src/address_index/database.rs
+++ b/src-tauri/src/address_index/database.rs
@@ -16,3 +16,30 @@ pub trait Database {
         Ok(())
     }
 }
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[derive(Default)]
+    pub struct MockDB {
+        address_map: HashMap<String, Vec<String>>,
+    }
+
+    impl Database for MockDB {
+        async fn get_address_txids(&self, address: &str) -> crate::error::Result<Vec<String>> {
+            Ok(self.address_map.get(address).unwrap_or(&vec![]).clone())
+        }
+
+        async fn store_tx(&mut self, tx: &Tx) -> crate::error::Result<()> {
+            for address in &tx.addresses {
+                self.address_map
+                    .entry(address.clone())
+                    .and_modify(|vec| vec.push(tx.txid.clone()))
+                    .or_insert(vec![tx.txid.clone()]);
+            }
+            Ok(())
+        }
+    }
+}

--- a/src-tauri/src/address_index/database.rs
+++ b/src-tauri/src/address_index/database.rs
@@ -1,0 +1,18 @@
+use super::types::Tx;
+
+pub trait Database {
+    async fn get_address_txids(&self, address: &str) -> crate::error::Result<Vec<String>>;
+    async fn store_tx(&mut self, tx: &Tx) -> crate::error::Result<()>;
+    /**
+     * Override if there is a more efficient way to store multiple txs at the same time
+     */
+    async fn store_txs<I>(&mut self, txs: I) -> crate::error::Result<()>
+    where
+        I: Iterator<Item = Tx>,
+    {
+        for tx in txs {
+            self.store_tx(&tx).await?;
+        }
+        Ok(())
+    }
+}

--- a/src-tauri/src/address_index/mod.rs
+++ b/src-tauri/src/address_index/mod.rs
@@ -1,0 +1,33 @@
+pub mod block_source;
+pub mod database;
+pub mod pivx_rpc;
+pub mod sql_lite;
+pub mod types;
+
+use block_source::BlockSource;
+use database::Database;
+use futures::StreamExt;
+
+pub struct AddressIndex<D: Database, B: BlockSource> {
+    database: D,
+    block_source: B,
+}
+
+impl<D: Database + Send, B: BlockSource + Send> AddressIndex<D, B> {
+    pub async fn sync(&mut self) -> crate::error::Result<()> {
+        println!("Starting sync");
+        let mut stream = self.block_source.get_blocks()?.chunks(10_000);
+        while let Some(blocks) = stream.next().await {
+            self.database
+                .store_txs(blocks.into_iter().flat_map(|block| block.txs.into_iter()))
+                .await?;
+        }
+        Ok(())
+    }
+    pub fn new(database: D, block_source: B) -> Self {
+        Self {
+            database,
+            block_source,
+        }
+    }
+}

--- a/src-tauri/src/address_index/pivx_rpc.rs
+++ b/src-tauri/src/address_index/pivx_rpc.rs
@@ -1,7 +1,7 @@
 use super::block_source::BlockSource;
 use super::types::Block;
-use futures::future::Pending;
-use futures::stream::{self, Stream};
+use base64::prelude::*;
+use futures::stream::Stream;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::rpc_params;
@@ -31,8 +31,9 @@ impl BlockStream {
         if let Err(ref err) = &block {
             eprintln!("{}", err);
         }
-        Some(block.ok()?)
+        block.ok()
     }
+
     pub fn new(client: HttpClient) -> Self {
         Self {
             client,
@@ -74,7 +75,8 @@ impl PIVXRpc {
         headers.insert(
             "Authorization",
             // TODO: remove unwrap
-            HeaderValue::from_str(&format!("Basic {}", base64::encode(credentials))).unwrap(),
+            HeaderValue::from_str(&format!("Basic {}", BASE64_STANDARD.encode(credentials)))
+                .unwrap(),
         );
         Ok(PIVXRpc {
             client: HttpClient::builder().set_headers(headers).build(url)?,

--- a/src-tauri/src/address_index/pivx_rpc.rs
+++ b/src-tauri/src/address_index/pivx_rpc.rs
@@ -1,0 +1,93 @@
+use super::block_source::BlockSource;
+use super::types::Block;
+use futures::future::Pending;
+use futures::stream::{self, Stream};
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::http_client::HttpClient;
+use jsonrpsee::rpc_params;
+use reqwest::header::{HeaderMap, HeaderValue};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pub struct PIVXRpc {
+    client: HttpClient,
+}
+
+struct BlockStream {
+    client: HttpClient,
+    current_block: u64,
+    current_future: Option<Pin<Box<dyn Future<Output = Option<Block>> + Send>>>,
+}
+
+impl BlockStream {
+    async fn get_next_block(client: HttpClient, current_block: u64) -> Option<Block> {
+        println!("current block: {}", current_block);
+        let hash: String = client
+            .request("getblockhash", rpc_params![current_block])
+            .await
+            .unwrap();
+        let block: Result<Block, _> = client.request("getblock", rpc_params![hash, 2]).await;
+        if let Err(ref err) = &block {
+            eprintln!("{}", err);
+        }
+        Some(block.ok()?)
+    }
+    pub fn new(client: HttpClient) -> Self {
+        Self {
+            client,
+            current_block: 0,
+            current_future: None,
+        }
+    }
+}
+
+impl Stream for BlockStream {
+    type Item = Block;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if let Some(ref mut future) = &mut self.current_future {
+            let poll = Pin::as_mut(future).poll(cx);
+            match poll {
+                Poll::Ready(i) => {
+                    self.current_future = None;
+                    Poll::Ready(i)
+                }
+                Poll::Pending => Poll::Pending,
+            }
+        } else {
+            self.as_mut().current_block = self.current_block + 1;
+            let new_future = Box::pin(Self::get_next_block(
+                self.client.clone(),
+                self.current_block,
+            ));
+            self.current_future = Some(new_future);
+            self.poll_next(cx)
+        }
+    }
+}
+
+impl PIVXRpc {
+    pub async fn new(url: &str) -> crate::error::Result<Self> {
+        let mut headers = HeaderMap::new();
+        let credentials = format!("{}:{}", crate::RPC_USERNAME, crate::RPC_PASSWORD);
+        headers.insert(
+            "Authorization",
+            // TODO: remove unwrap
+            HeaderValue::from_str(&format!("Basic {}", base64::encode(credentials))).unwrap(),
+        );
+        Ok(PIVXRpc {
+            client: HttpClient::builder().set_headers(headers).build(url)?,
+        })
+    }
+}
+
+impl BlockSource for PIVXRpc {
+    fn get_blocks(
+        &mut self,
+    ) -> crate::error::Result<Pin<Box<dyn Stream<Item = Block> + Send + '_>>> {
+        let block_stream = BlockStream::new(self.client.clone());
+
+        Ok(Box::pin(block_stream))
+    }
+}

--- a/src-tauri/src/address_index/sql_lite.rs
+++ b/src-tauri/src/address_index/sql_lite.rs
@@ -1,0 +1,68 @@
+use std::path::PathBuf;
+
+use super::database::Database;
+use super::types::Tx;
+use rusqlite::{params, Connection};
+
+pub struct SqlLite {
+    connection: Connection,
+}
+
+impl SqlLite {
+    pub async fn new(path: &PathBuf) -> crate::error::Result<Self> {
+        let path = path.clone();
+        tauri::async_runtime::spawn_blocking(move || {
+	    let connection = Connection::open(path)?;
+	    connection.execute_batch("
+BEGIN;
+CREATE TABLE IF NOT EXISTS transactions(txid TEXT NOT NULL, address TEXT NOT NULL, PRIMARY KEY (txid, address));
+CREATE INDEX IF NOT EXISTS idx_address ON transactions (address);
+COMMIT;
+")?;
+	    Ok(Self{connection})
+	}).await?
+    }
+}
+
+impl Database for SqlLite {
+    async fn get_address_txids(&self, address: &str) -> crate::error::Result<Vec<String>> {
+        let mut stmt = self
+            .connection
+            .prepare("SELECT txid FROM transaction WHERE address=?1")?;
+        let mut rows = stmt.query([address])?;
+        let mut txids = vec![];
+        while let Some(row) = rows.next()? {
+            let txid: String = row.get(0)?;
+            txids.push(txid);
+        }
+        Ok(txids)
+    }
+    async fn store_tx(&mut self, tx: &Tx) -> crate::error::Result<()> {
+        let txid = &tx.txid;
+        let mut stmt = self
+            .connection
+            .prepare("INSERT OR IGNORE INTO transactions (txid, address) VALUES (?1, ?2);")?;
+        for address in &tx.addresses {
+            stmt.execute(params![txid, &address])?;
+        }
+        Ok(())
+    }
+
+    async fn store_txs<I>(&mut self, txs: I) -> crate::error::Result<()>
+    where
+        I: Iterator<Item = Tx>,
+    {
+        let connection = self.connection.transaction()?;
+        for tx in txs {
+            let txid = &tx.txid;
+            for address in &tx.addresses {
+                connection.execute(
+                    "INSERT OR IGNORE INTO transactions (txid, address) VALUES (?1, ?2);",
+                    params![txid, &address],
+                )?;
+            }
+        }
+        connection.commit()?;
+        Ok(())
+    }
+}

--- a/src-tauri/src/address_index/sql_lite.rs
+++ b/src-tauri/src/address_index/sql_lite.rs
@@ -9,8 +9,7 @@ pub struct SqlLite {
 }
 
 impl SqlLite {
-    pub async fn new(path: &PathBuf) -> crate::error::Result<Self> {
-        let path = path.clone();
+    pub async fn new(path: PathBuf) -> crate::error::Result<Self> {
         tauri::async_runtime::spawn_blocking(move || {
 	    let connection = Connection::open(path)?;
 	    connection.execute_batch("
@@ -91,7 +90,7 @@ mod test {
     #[tokio::test]
     async fn test_sqlite() -> crate::error::Result<()> {
         let temp_dir = TempDir::new("sqlite-test")?;
-        let mut sql_lite = SqlLite::new(&temp_dir.path().join("test.sqlite")).await?;
+        let mut sql_lite = SqlLite::new(temp_dir.path().join("test.sqlite")).await?;
         let test_blocks = get_test_blocks();
         for block in test_blocks {
             for tx in block.txs {
@@ -105,7 +104,7 @@ mod test {
     #[tokio::test]
     async fn test_sqlite_batch() -> crate::error::Result<()> {
         let temp_dir = TempDir::new("sqlite-test-batch")?;
-        let mut sql_lite = SqlLite::new(&temp_dir.path().join("test.sqlite")).await?;
+        let mut sql_lite = SqlLite::new(temp_dir.path().join("test.sqlite")).await?;
         let test_blocks = get_test_blocks();
         sql_lite
             .store_txs(

--- a/src-tauri/src/address_index/types.rs
+++ b/src-tauri/src/address_index/types.rs
@@ -1,0 +1,89 @@
+use serde::{Deserialize, Deserializer};
+
+#[derive(Deserialize, Debug)]
+pub struct Block {
+    #[serde(rename = "tx")]
+    pub txs: Vec<Tx>,
+}
+#[derive(Deserialize, Debug)]
+pub struct Tx {
+    pub txid: String,
+
+    #[serde(deserialize_with = "concat_addresses")]
+    #[serde(rename = "vout")]
+    pub addresses: Vec<String>,
+}
+
+#[derive(Deserialize, Debug)]
+struct Vout {
+    #[serde(rename = "scriptPubKey")]
+    pub script_pub_key: Option<ScriptPubKey>,
+}
+#[derive(Deserialize, Debug)]
+struct ScriptPubKey {
+    pub addresses: Option<Vec<String>>,
+}
+
+fn concat_addresses<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let vouts: Vec<Vout> = Vec::deserialize(deserializer)?;
+    let mut addresses: Vec<String> = vec![];
+    for vout in vouts {
+        if let Some(vout_addresses) = vout.script_pub_key.and_then(|s| s.addresses) {
+            addresses.extend(vout_addresses);
+        }
+    }
+    Ok(addresses)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_deserialization() -> Result<(), Box<dyn std::error::Error>> {
+        let block: Block = serde_json::from_str(
+            r#"
+{
+    "tx": [
+        {
+            "txid": "123",
+            "vout": [
+                {
+                    "addresses": ["Address1"]
+                },
+                {
+                    "addresses": ["Address2"]
+                }
+            ]
+        },
+        {
+            "txid": "456",
+            "vout": [
+                {
+                },
+                {
+                    "addresses": ["Address3"]
+                },
+                {
+                    "addresses": ["Address4", "Address5"]
+                }
+            ]
+        }
+    ]
+}
+"#,
+        )?;
+        assert_eq!(block.txs.len(), 2);
+        assert_eq!(block.txs[0].txid, "123");
+        assert_eq!(block.txs[1].txid, "456");
+        assert_eq!(block.txs[0].addresses, vec!["Address1", "Address2"]);
+        assert_eq!(
+            block.txs[1].addresses,
+            vec!["Address3", "Address4", "Address5"]
+        );
+        Ok(())
+    }
+}

--- a/src-tauri/src/address_index/types.rs
+++ b/src-tauri/src/address_index/types.rs
@@ -52,10 +52,15 @@ mod test {
             "txid": "123",
             "vout": [
                 {
-                    "addresses": ["Address1"]
+
+                    "scriptPubKey": {
+                        "addresses": ["Address1"]
+                    }
                 },
                 {
-                    "addresses": ["Address2"]
+                    "scriptPubKey": {
+                        "addresses": ["Address2"]
+                    }
                 }
             ]
         },
@@ -65,10 +70,14 @@ mod test {
                 {
                 },
                 {
-                    "addresses": ["Address3"]
+                    "scriptPubKey": {
+                        "addresses": ["Address3"]
+                    }
                 },
                 {
-                    "addresses": ["Address4", "Address5"]
+                    "scriptPubKey": {
+                        "addresses": ["Address4", "Address5"]
+                    }
                 }
             ]
         }

--- a/src-tauri/src/address_index/types.rs
+++ b/src-tauri/src/address_index/types.rs
@@ -39,8 +39,31 @@ where
 }
 
 #[cfg(test)]
-mod test {
+pub mod test {
     use super::*;
+
+    pub fn get_test_blocks() -> Vec<Block> {
+        vec![
+            Block {
+                txs: vec![Tx {
+                    txid: "txid1".to_owned(),
+                    addresses: vec!["address1".to_owned(), "address2".to_owned()],
+                }],
+            },
+            Block {
+                txs: vec![Tx {
+                    txid: "txid2".to_owned(),
+                    addresses: vec!["address1".to_owned(), "address4".to_owned()],
+                }],
+            },
+            Block {
+                txs: vec![Tx {
+                    txid: "txid3".to_owned(),
+                    addresses: vec!["address1".to_owned(), "address5".to_owned()],
+                }],
+            },
+        ]
+    }
 
     #[test]
     fn test_deserialization() -> Result<(), Box<dyn std::error::Error>> {

--- a/src-tauri/src/binary/mod.rs
+++ b/src-tauri/src/binary/mod.rs
@@ -5,7 +5,7 @@ use crate::error::PIVXErrors;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
-use std::process::{Child, Command};
+use std::process::{Child, Command, Stdio};
 
 pub trait BinaryDefinition {
     fn get_url(&self) -> &str;
@@ -13,7 +13,7 @@ pub trait BinaryDefinition {
     fn get_archive_name(&self) -> &str;
     fn decompress_archive(&self, dir: &PathBuf) -> Result<(), PIVXErrors>;
     fn get_binary_path(&self, base_dir: &PathBuf) -> PathBuf;
-    fn get_binary_args(&self, base_dir: &PathBuf) -> Result<String, PIVXErrors>;
+    fn get_binary_args(&self, base_dir: &PathBuf) -> Result<Vec<String>, PIVXErrors>;
 }
 
 pub struct Binary {
@@ -78,7 +78,8 @@ impl Binary {
             std::fs::create_dir_all(&data_dir)?;
         }
         let handle = Command::new(path)
-            .arg(binary_definition.get_binary_args(&data_dir)?)
+            .args(binary_definition.get_binary_args(&data_dir)?)
+            .stdout(Stdio::null())
             .spawn()
             .map_err(|_| PIVXErrors::PivxdNotFound)?;
         Ok(Binary { handle })

--- a/src-tauri/src/binary/test.rs
+++ b/src-tauri/src/binary/test.rs
@@ -22,7 +22,7 @@ impl BinaryDefinition for TestBinary {
     fn get_binary_path(&self, base_dir: &PathBuf) -> PathBuf {
         unimplemented!()
     }
-    fn get_binary_args(&self, _: &PathBuf) -> Result<String, PIVXErrors> {
+    fn get_binary_args(&self, _: &PathBuf) -> Result<Vec<String>, PIVXErrors> {
         unimplemented!()
     }
 }

--- a/src-tauri/src/binary/test.rs
+++ b/src-tauri/src/binary/test.rs
@@ -1,6 +1,4 @@
 use super::*;
-use std::fs::File;
-use tempdir::TempDir;
 
 struct TestBinary {
     url: String,
@@ -16,13 +14,13 @@ impl BinaryDefinition for TestBinary {
     fn get_archive_name(&self) -> &str {
         "a.tar.gz"
     }
-    fn decompress_archive(&self, dir: &PathBuf) -> Result<(), PIVXErrors> {
+    fn decompress_archive(&self, _dir: &Path) -> Result<(), PIVXErrors> {
         Ok(())
     }
-    fn get_binary_path(&self, base_dir: &PathBuf) -> PathBuf {
+    fn get_binary_path(&self, _base_dir: &Path) -> PathBuf {
         unimplemented!()
     }
-    fn get_binary_args(&self, _: &PathBuf) -> Result<Vec<String>, PIVXErrors> {
+    fn get_binary_args(&self, _: &Path) -> Result<Vec<String>, PIVXErrors> {
         unimplemented!()
     }
 }
@@ -49,7 +47,7 @@ mod pivx_fetch {
     async fn returns_error_when_server_returns_404() -> Result<(), PIVXErrors> {
         let data_dir = Binary::get_data_dir()?;
         let mut server = mockito::Server::new_async().await;
-        let m1 = server
+        server
             .mock("GET", "/")
             .with_status(500)
             .with_body("Internal server error.")
@@ -57,7 +55,7 @@ mod pivx_fetch {
             .await;
         let binary_definition = TestBinary { url: server.url() };
         match Binary::fetch(&data_dir, &binary_definition).await {
-            Err(x) => {}
+            Err(_) => {}
             Ok(_) => panic!("Shuold return error"),
         };
 

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -21,6 +21,15 @@ pub enum PIVXErrors {
 
     #[error("Invalid sha256 sum")]
     WrongSha256Sum(Option<std::io::Error>),
+
+    #[error("Unable to connect to pivxd")]
+    UnableToAuthPIVXD(#[from] jsonrpsee::core::ClientError),
+
+    #[error("Error with Sqlite")]
+    SqliteError(#[from] rusqlite::Error),
+
+    #[error("Tauri error")]
+    TauriError(#[from] tauri::Error),
 }
 
 pub type Result<T> = std::result::Result<T, PIVXErrors>;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,7 +1,7 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::{path::PathBuf, time::Duration};
+use std::path::PathBuf;
 
 use address_index::{pivx_rpc::PIVXRpc, sql_lite::SqlLite, AddressIndex};
 use pivx::PIVXDefinition;
@@ -24,7 +24,7 @@ async fn greet() -> Result<String, ()> {
         .expect("Failed to run PIVX");
 
     let mut address_index = AddressIndex::new(
-        SqlLite::new(&PathBuf::from("/home/duddino/test.sqlite"))
+        SqlLite::new(PathBuf::from("/home/duddino/test.sqlite"))
             .await
             .unwrap(),
         PIVXRpc::new(&format!("http://127.0.0.1:{}", RPC_PORT))

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,22 +1,41 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use std::{path::PathBuf, time::Duration};
+
+use address_index::{pivx_rpc::PIVXRpc, sql_lite::SqlLite, AddressIndex};
 use pivx::PIVXDefinition;
 
+mod address_index;
 mod binary;
 mod error;
 mod pivx;
 
+pub const RPC_PORT: u16 = 51473;
+pub const RPC_USERNAME: &str = "username";
+pub const RPC_PASSWORD: &str = "password";
+
 // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
 #[tauri::command]
-async fn greet() -> String {
+async fn greet() -> Result<String, ()> {
     let pivx_definition = PIVXDefinition;
     let pivx = binary::Binary::new_by_fetching(&pivx_definition)
         .await
         .expect("Failed to run PIVX");
+
+    let mut address_index = AddressIndex::new(
+        SqlLite::new(&PathBuf::from("/home/duddino/test.sqlite"))
+            .await
+            .unwrap(),
+        PIVXRpc::new(&format!("http://127.0.0.1:{}", RPC_PORT))
+            .await
+            .unwrap(),
+    );
+    //tokio::time::sleep(Duration::from_secs(60)).await;
     // Leaking for now to bypass Drop
     Box::leak(Box::new(pivx));
-    "PIVX Started succesfully".into()
+    address_index.sync().await.unwrap();
+    Ok("PIVX Started succesfully".into())
 }
 
 fn main() {

--- a/src-tauri/src/pivx/mod.rs
+++ b/src-tauri/src/pivx/mod.rs
@@ -52,10 +52,14 @@ impl BinaryDefinition for PIVXDefinition {
         base_dir.join("pivx-5.6.1").join("bin").join("pivxd")
     }
 
-    fn get_binary_args(&self, base_dir: &PathBuf) -> Result<String, PIVXErrors> {
-        Ok(format!(
-            "-datadir={}",
-            base_dir.to_str().ok_or(PIVXErrors::PivxdNotFound)?
-        ))
+    fn get_binary_args(&self, base_dir: &PathBuf) -> Result<Vec<String>, PIVXErrors> {
+        let args = format!(
+            "-datadir={} -rpcport={} -rpcuser={} -rpcpassword={}",
+            base_dir.to_str().ok_or(PIVXErrors::PivxdNotFound)?,
+            crate::RPC_PORT,
+            crate::RPC_USERNAME,
+            crate::RPC_PASSWORD,
+        );
+        Ok(args.split(" ").map(|s| s.to_string()).collect::<Vec<_>>())
     }
 }

--- a/src-tauri/src/pivx/mod.rs
+++ b/src-tauri/src/pivx/mod.rs
@@ -4,7 +4,7 @@ mod test;
 use crate::error::PIVXErrors;
 use flate2::read::GzDecoder;
 use std::fs::File;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tar::Archive;
 
 use crate::binary::BinaryDefinition;
@@ -12,7 +12,7 @@ use crate::binary::BinaryDefinition;
 pub struct PIVXDefinition;
 
 impl BinaryDefinition for PIVXDefinition {
-    fn decompress_archive(&self, dir: &PathBuf) -> Result<(), PIVXErrors> {
+    fn decompress_archive(&self, dir: &Path) -> Result<(), PIVXErrors> {
         let mut tarball = Archive::new(GzDecoder::new(File::open(dir.join("pivxd.tar.gz"))?));
         tarball.unpack(dir)?;
 
@@ -48,11 +48,11 @@ impl BinaryDefinition for PIVXDefinition {
         }
     }
 
-    fn get_binary_path(&self, base_dir: &PathBuf) -> PathBuf {
+    fn get_binary_path(&self, base_dir: &Path) -> PathBuf {
         base_dir.join("pivx-5.6.1").join("bin").join("pivxd")
     }
 
-    fn get_binary_args(&self, base_dir: &PathBuf) -> Result<Vec<String>, PIVXErrors> {
+    fn get_binary_args(&self, base_dir: &Path) -> Result<Vec<String>, PIVXErrors> {
         let args = format!(
             "-datadir={} -rpcport={} -rpcuser={} -rpcpassword={}",
             base_dir.to_str().ok_or(PIVXErrors::PivxdNotFound)?,


### PR DESCRIPTION
Add address indexer system to replace explorer, since it's not worth it to self host it for each instance (+ needs to be compiled for windows & mac and need to figure out all the dependencies).
The system is composed of two parts:
- Database: A trait to store addresses. This is implemented with SqlLite. With some rough testing, it took 1.1548 seconds to index 10000 blocks, which is about 9 minutes to index the whole blockchain. Space estimate is <10GB (probably way less, can be optimized by storing bytes instead of string)
- BlockSource: This trait returns a stream of blocks to be indexed by the Database. This was implemented by calling the `getblock` RPC, and is orders of magnitude slower than the Database. This can be optimized by reading the pivx database files directly, or modifying the source to return a lighter version of the blocks (a hex for the block and each tx is return at the moment)

TODO:
- [x] Clean up code
- [x] Tests