### PR TITLE
Resume sync if using IndexedBlockSource

### DIFF
--- a/src-tauri/src/address_index/block_file_source.rs
+++ b/src-tauri/src/address_index/block_file_source.rs
@@ -71,9 +71,7 @@ impl Iterator for BlockFileIterator {
 }
 
 impl BlockSource for BlockFileSource {
-    fn get_blocks(
-        &mut self,
-    ) -> crate::error::Result<Pin<Box<dyn Stream<Item = Block> + '_ + Send>>> {
+    fn get_blocks(&self) -> crate::error::Result<Pin<Box<dyn Stream<Item = Block> + '_ + Send>>> {
         let block_file_iterator = BlockFileIterator::new(&self.db_path);
         Ok(Box::pin(stream::iter(block_file_iterator)))
     }

--- a/src-tauri/src/address_index/block_source.rs
+++ b/src-tauri/src/address_index/block_source.rs
@@ -1,11 +1,52 @@
 use super::types::Block;
 use futures::stream::Stream;
-use std::pin::Pin;
+use futures::Future;
+use serde_json::value::Index;
+use std::{ops::Deref, pin::Pin, sync::Arc};
+
+pub type PinnedStream<'a, T> = Pin<Box<dyn Stream<Item = T> + 'a + Send>>;
+pub type BS = Arc<dyn BlockSource + 'static + Send + Sync>;
+pub type IBS = Arc<dyn IndexedBlockSource + 'static + Send + Sync>;
+
+#[derive(Clone)]
+pub enum BlockSourceType {
+    Regular(BS),
+    Indexed(IBS),
+}
+
+impl Deref for BlockSourceType {
+    type Target = dyn BlockSource;
+
+    fn deref<'a>(&'a self) -> &'a Self::Target {
+        match self {
+            Self::Regular(ref d) => return d.as_ref(),
+            Self::Indexed(ref d) => return d.as_ref().as_block_source(),
+        }
+    }
+}
 
 pub trait BlockSource {
-    fn get_blocks(
-        &mut self,
-    ) -> crate::error::Result<Pin<Box<dyn Stream<Item = Block> + '_ + Send>>>;
+    fn get_blocks(&self) -> crate::error::Result<PinnedStream<'_, Block>>;
+
+    // IndexedBlockSource must override this.
+    fn instantiate(self) -> BlockSourceType
+    where
+        Self: Sized + 'static + Send + Sync,
+    {
+        BlockSourceType::Regular(Arc::new(self))
+    }
+}
+
+pub trait IndexedBlockSource: BlockSource {
+    /**
+     * Returns a stream of blocks with associated block count.
+     * Stream must be sorted by block count
+     */
+    fn get_blocks_indexed(
+        &self,
+        start_from: u64,
+    ) -> crate::error::Result<PinnedStream<'_, (Block, u64)>>;
+    fn as_block_source(&self) -> &(dyn BlockSource + Send + Sync + 'static);
 }
 
 #[cfg(test)]
@@ -17,7 +58,7 @@ pub mod test {
 
     impl BlockSource for MockBlockSource {
         fn get_blocks(
-            &mut self,
+            &self,
         ) -> crate::error::Result<Pin<Box<dyn Stream<Item = Block> + '_ + Send>>> {
             Ok(Box::pin(futures::stream::iter(get_test_blocks())))
         }

--- a/src-tauri/src/address_index/block_source.rs
+++ b/src-tauri/src/address_index/block_source.rs
@@ -1,23 +1,21 @@
 use super::types::Block;
 use futures::stream::Stream;
-use futures::Future;
-use serde_json::value::Index;
 use std::{ops::Deref, pin::Pin, sync::Arc};
 
 pub type PinnedStream<'a, T> = Pin<Box<dyn Stream<Item = T> + 'a + Send>>;
-pub type BS = Arc<dyn BlockSource + 'static + Send + Sync>;
-pub type IBS = Arc<dyn IndexedBlockSource + 'static + Send + Sync>;
+pub type Bs = Arc<dyn BlockSource + 'static + Send + Sync>;
+pub type Ibs = Arc<dyn IndexedBlockSource + 'static + Send + Sync>;
 
 #[derive(Clone)]
 pub enum BlockSourceType {
-    Regular(BS),
-    Indexed(IBS),
+    Regular(Bs),
+    Indexed(Ibs),
 }
 
 impl Deref for BlockSourceType {
     type Target = dyn BlockSource;
 
-    fn deref<'a>(&'a self) -> &'a Self::Target {
+    fn deref(&self) -> &Self::Target {
         match self {
             Self::Regular(ref d) => return d.as_ref(),
             Self::Indexed(ref d) => return d.as_ref().as_block_source(),

--- a/src-tauri/src/address_index/database.rs
+++ b/src-tauri/src/address_index/database.rs
@@ -1,3 +1,5 @@
+use futures::Future;
+
 use super::types::{Tx, Vin};
 
 pub trait Database {
@@ -15,6 +17,21 @@ pub trait Database {
             self.store_tx(&tx).await?;
         }
         Ok(())
+    }
+
+    /**
+     * Update block count lower bound, if available.
+     * Must not be called with block_count lower than a previous call
+     */
+    async fn update_block_count(&mut self, _block_count: u64) -> crate::error::Result<()> {
+        Ok(())
+    }
+
+    /**
+     * Return a lower bound on the last indexed block for faster syncing
+     */
+    fn get_last_indexed_block(&self) -> impl Future<Output = crate::error::Result<u64>> {
+        async { Ok(0) }
     }
 }
 

--- a/src-tauri/src/address_index/pivx_rpc/mod.rs
+++ b/src-tauri/src/address_index/pivx_rpc/mod.rs
@@ -3,10 +3,11 @@ mod test;
 
 use crate::error::PIVXErrors;
 
-use super::block_source::BlockSource;
+use super::block_source::{BlockSource, BlockSourceType, IndexedBlockSource, PinnedStream};
 use super::types::Block;
 use base64::prelude::*;
 use futures::stream::Stream;
+use futures::StreamExt;
 use json_rpc::HttpClient;
 use jsonrpsee::core::traits::ToRpcParams;
 use jsonrpsee::rpc_params;
@@ -14,6 +15,7 @@ use reqwest::header::{HeaderMap, HeaderValue};
 use serde::de::DeserializeOwned;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 #[derive(Clone)]
@@ -24,11 +26,11 @@ pub struct PIVXRpc {
 struct BlockStream {
     client: HttpClient,
     current_block: u64,
-    current_future: Option<Pin<Box<dyn Future<Output = Option<Block>> + Send>>>,
+    current_future: Option<Pin<Box<dyn Future<Output = Option<(Block, u64)>> + Send>>>,
 }
 
 impl BlockStream {
-    async fn get_next_block(client: HttpClient, current_block: u64) -> Option<Block> {
+    async fn get_next_block(client: HttpClient, current_block: u64) -> Option<(Block, u64)> {
         println!("current block: {}", current_block);
         let hash: String = client
             .request::<_, (), _>("getblockhash", rpc_params![current_block])
@@ -40,7 +42,7 @@ impl BlockStream {
         if let Err(ref err) = &block {
             eprintln!("{}", err);
         }
-        block.ok()
+        block.ok().map(|b| (b, current_block))
     }
 
     pub fn new(client: HttpClient) -> Self {
@@ -50,10 +52,18 @@ impl BlockStream {
             current_future: None,
         }
     }
+
+    pub fn with_starting_block(client: HttpClient, starting_block: u64) -> Self {
+        Self {
+            client,
+            current_block: starting_block,
+            current_future: None,
+        }
+    }
 }
 
 impl Stream for BlockStream {
-    type Item = Block;
+    type Item = (Block, u64);
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         if let Some(ref mut future) = &mut self.current_future {
@@ -106,11 +116,26 @@ impl PIVXRpc {
 }
 
 impl BlockSource for PIVXRpc {
-    fn get_blocks(
-        &mut self,
-    ) -> crate::error::Result<Pin<Box<dyn Stream<Item = Block> + Send + '_>>> {
-        let block_stream = BlockStream::new(self.client.clone());
+    fn get_blocks(&self) -> crate::error::Result<Pin<Box<dyn Stream<Item = Block> + Send + '_>>> {
+        Ok(Box::pin(self.get_blocks_indexed(0)?.map(|(b, _)| b)))
+    }
+
+    fn instantiate(self) -> BlockSourceType {
+        BlockSourceType::Indexed(Arc::new(self))
+    }
+}
+
+impl IndexedBlockSource for PIVXRpc {
+    fn get_blocks_indexed(
+        &self,
+        start_from: u64,
+    ) -> crate::error::Result<PinnedStream<'_, (Block, u64)>> {
+        let block_stream = BlockStream::with_starting_block(self.client.clone(), start_from);
 
         Ok(Box::pin(block_stream))
+    }
+
+    fn as_block_source(&self) -> &(dyn BlockSource + Send + Sync + 'static) {
+        self
     }
 }

--- a/src-tauri/src/address_index/pivx_rpc/mod.rs
+++ b/src-tauri/src/address_index/pivx_rpc/mod.rs
@@ -23,10 +23,12 @@ pub struct PIVXRpc {
     client: HttpClient,
 }
 
+type BlockStreamFuture = Pin<Box<dyn Future<Output = Option<(Block, u64)>> + Send>>;
+
 struct BlockStream {
     client: HttpClient,
     current_block: u64,
-    current_future: Option<Pin<Box<dyn Future<Output = Option<(Block, u64)>> + Send>>>,
+    current_future: Option<BlockStreamFuture>,
 }
 
 impl BlockStream {

--- a/src-tauri/src/explorer/mod.rs
+++ b/src-tauri/src/explorer/mod.rs
@@ -1,15 +1,14 @@
-use error::PIVXErrors;
+use crate::error::PIVXErrors;
 use jsonrpsee::rpc_params;
 use serde::Deserialize;
 use std::path::PathBuf;
 use tokio::sync::OnceCell;
-// TODO: remove this import
-use crate::*;
 
 use crate::address_index::{
-    block_source::BlockSource, database::Database, pivx_rpc::PIVXRpc, sql_lite::SqlLite,
-    types::Vin, AddressIndex,
+    database::Database, pivx_rpc::PIVXRpc, sql_lite::SqlLite, types::Vin, AddressIndex,
 };
+use crate::binary::Binary;
+use crate::{PIVXDefinition, RPC_PORT};
 use global_function_macro::generate_global_functions;
 
 //#[derive(Deserialize, Serialize)]
@@ -49,7 +48,7 @@ async fn get_explorer() -> &'static DefaultExplorer {
     EXPLORER
         .get_or_init(|| async {
             let pivx_definition = PIVXDefinition;
-            let pivx = binary::Binary::new_by_fetching(&pivx_definition)
+            let pivx = Binary::new_by_fetching(&pivx_definition)
                 .await
                 .expect("Failed to run PIVX");
             let pivx_rpc = PIVXRpc::new(&format!("http://127.0.0.1:{}", RPC_PORT))

--- a/src-tauri/src/explorer/mod.rs
+++ b/src-tauri/src/explorer/mod.rs
@@ -21,23 +21,21 @@ type TxHexWithBlockCount = (String, u64, u64);
 }*/
 
 #[derive(Clone)]
-pub struct Explorer<D, B>
+pub struct Explorer<D>
 where
     D: Database,
-    B: BlockSource,
 {
-    address_index: AddressIndex<D, B>,
+    address_index: AddressIndex<D>,
     pivx_rpc: PIVXRpc,
 }
 
-type DefaultExplorer = Explorer<SqlLite, PIVXRpc>;
+type DefaultExplorer = Explorer<SqlLite>;
 
-impl<D, B> Explorer<D, B>
+impl<D> Explorer<D>
 where
     D: Database + Send + Clone,
-    B: BlockSource + Send + Clone,
 {
-    fn new(address_index: AddressIndex<D, B>, rpc: PIVXRpc) -> Self {
+    fn new(address_index: AddressIndex<D>, rpc: PIVXRpc) -> Self {
         Self {
             address_index,
             pivx_rpc: rpc,
@@ -81,10 +79,9 @@ async fn get_explorer() -> &'static DefaultExplorer {
 }
 
 #[generate_global_functions]
-impl<D, B> Explorer<D, B>
+impl<D> Explorer<D>
 where
     D: Database + Send + Clone,
-    B: BlockSource + Send + Clone,
 {
     pub async fn get_block(&self, block_height: u64) -> crate::error::Result<String> {
         let block_hash: String = self

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,9 +1,6 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::path::PathBuf;
-
-use address_index::{block_file_source::BlockFileSource, sql_lite::SqlLite, AddressIndex};
 use pivx::PIVXDefinition;
 
 mod address_index;
@@ -15,31 +12,6 @@ mod pivx;
 pub const RPC_PORT: u16 = 51473;
 pub const RPC_USERNAME: &str = "username";
 pub const RPC_PASSWORD: &str = "password";
-
-// Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
-#[tauri::command]
-async fn greet() -> Result<String, ()> {
-    let _pivx_definition = PIVXDefinition;
-    /*let pivx = binary::Binary::new_by_fetching(&pivx_definition)
-    .await
-    .expect("Failed to run PIVX");*/
-    let now = tokio::time::Instant::now();
-    let mut address_index = AddressIndex::new(
-        SqlLite::new(PathBuf::from("/home/duddino/test.sqlite"))
-            .await
-            .unwrap(),
-        /*PIVXRpc::new(&format!("http://127.0.0.1:{}", RPC_PORT))
-            .await
-        .unwrap(),*/
-        BlockFileSource::new("/home/duddino/.local/share/pivx-rust/.pivx/blocks/"),
-    );
-    //tokio::time::sleep(Duration::from_secs(60)).await;
-    // Leaking for now to bypass Drop
-    //Box::leak(Box::new(pivx));
-    address_index.sync().await.unwrap();
-    println!("elapsed {:?}", now.elapsed());
-    Ok("PIVX Started succesfully".into())
-}
 
 fn main() {
     use explorer::auto_generated::*;
@@ -56,15 +28,4 @@ fn main() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    // Uncomment to start manual testing without having to run MPW
-    // #[tokio::test]
-    #[allow(unused)]
-    async fn main_test() {
-        greet().await.unwrap();
-    }
 }


### PR DESCRIPTION
This PR adds the `IndexedBlockSource` trait, which is a `BlockSource` that returns blocks sorted by their block count, along with the block count itself. 
Changed AddressIndex struct to take a trait object for the BlockSource, to allow dynamic dispatching over the BlockSource, and to potentially change BlockSource impl at run time in the future.
Using those traits, if available, the database will store the block count and resume from where it left off during sync