### PR TITLE
Add sync loading bar

### DIFF
--- a/src-tauri/src/explorer/mod.rs
+++ b/src-tauri/src/explorer/mod.rs
@@ -24,6 +24,12 @@ where
     pivx_rpc: PIVXRpc,
 }
 
+#[derive(Deserialize)]
+struct ChainInfo {
+    verificationprogress: f64,
+    initial_block_downloading: bool,
+}
+
 type DefaultExplorer = Explorer<SqlLite>;
 
 impl<D> Explorer<D>
@@ -202,5 +208,21 @@ where
             .await
             .set_block_source(block_file_source);
         Ok(())
+    }
+
+    pub async fn is_initial_sync(&self) -> crate::error::Result<bool> {
+        let chain_info: ChainInfo = self
+            .pivx_rpc
+            .call("getblockchaininfo", rpc_params![])
+            .await?;
+        Ok(chain_info.initial_block_downloading)
+    }
+
+    pub async fn get_sync_progress(&self) -> crate::error::Result<f64> {
+        let chain_info: ChainInfo = self
+            .pivx_rpc
+            .call("getblockchaininfo", rpc_params![])
+            .await?;
+        Ok(chain_info.verificationprogress)
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -27,6 +27,8 @@ fn main() {
             explorer_sync,
             explorer_switch_to_rpc_source,
             explorer_switch_to_blockfile_source,
+            explorer_is_initial_sync,
+            explorer_get_sync_progress,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
Add a sync loading bar to prevent the use of MPW when the node is not fully synced.
![image](https://github.com/user-attachments/assets/3836cf94-cc0e-4c1c-97ec-9281bedd802b)
